### PR TITLE
Adding a warning message if the lambda function names specified does not...

### DIFF
--- a/tasks/lambda_deploy.js
+++ b/tasks/lambda_deploy.js
@@ -44,6 +44,12 @@ module.exports = function (grunt) {
 
         lambda.getFunction({FunctionName: deploy_function}, function (err, data) {
 
+            if (data === null)
+            {
+                grunt.fail.warn('Unable to find lambda function ' + deploy_function + ' , verify the lambda function name and AWS region are correct');
+            }
+
+
             var current = data.Configuration;
 
             var params = {


### PR DESCRIPTION
I've added a simple grunt warning message if the AWS Lambda function name does not already exist.
This tripped me up because I'm running in an AWS region different the default region ...
