### PR TITLE
Making the Lambda timeout value configurable from grunt options file

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,12 @@ Default value: `us-east-1`
 Specify the AWS region, useful if you'd normally operate in a certain region (such as one where Lambda isn't yet available)
  but wish to upload functions to another region.
 
+##### options.timeout
+Type: `Integer`
+Default value: `null`
+Depending on your Lambda function, you might need to increase the timeout value. The default timeout assigned by AWS is currently 3 seconds.
+ If you wish to increase this timeout set the value here.
+
 #### Usage Examples
 
 ##### Default Options
@@ -355,7 +361,23 @@ grunt.initConfig({
     }
 });
 ```
-And now if you run `grunt lambda_deploy` your package shoudl be created and uploaded to the specified function.
+And now if you run `grunt lambda_deploy` your package should be created and uploaded to the specified function.
+
+
+##### Increasing the Timeout Options to 10 seconds
+In this example, the timeout value is increased to 10 seconds.
+
+```js
+grunt.initConfig({
+    lambda_deploy: {
+        default: {
+            function: 'my-lambda-function',
+            timeout : 10
+
+        }
+    }
+});
+```
 
 ## Misc info
 

--- a/tasks/lambda_deploy.js
+++ b/tasks/lambda_deploy.js
@@ -35,6 +35,7 @@ module.exports = function (grunt) {
 
         var deploy_function = grunt.config.get('lambda_deploy.' + this.target + '.function');
         var deploy_package = grunt.config.get('lambda_deploy.' + this.target + '.package');
+        var deploy_timeout = grunt.config.get('lambda_deploy.' + this.target + '.options.timeout');
 
         AWS.config.update({region: options.region});
 
@@ -61,6 +62,11 @@ module.exports = function (grunt) {
                 Role: current.Role,
                 Runtime: current.Runtime
             };
+
+            if (deploy_timeout !== null)
+            {
+                params.Timeout = deploy_timeout;
+            }
 
             grunt.log.writeln('Uploading...');
             fs.readFile(deploy_package, function (err, data) {


### PR DESCRIPTION
I'd like to add a configuration option to make it possible to increase the timeout value for the AWS Lambda function.
I think it's best not to default an initial value for this property as AWS may decide to change the default value from a 3 seconds timeout to something else  in future....

