### PR TITLE
Add npm to dev dependencies when npm is not in the path

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         "grunt-contrib-clean": "^0.5.0",
         "grunt-contrib-nodeunit": "^0.3.3",
         "grunt": "~0.4.5",
-        "adm-zip": "~0.4.4"
+        "adm-zip": "~0.4.4",
+        "npm": "^2.10.0"
     },
     "peerDependencies": {
         "grunt": "~0.4.5"


### PR DESCRIPTION
This should fix tests.  Also should fix #2