### PR TITLE
JSHint semicolon fixes for lambda_deploy.js

### DIFF
--- a/tasks/lambda_deploy.js
+++ b/tasks/lambda_deploy.js
@@ -90,7 +90,7 @@ module.exports = function (grunt) {
                     callback(false);
                     return;
                 }
-            }
+            };
 
             grunt.log.writeln('Uploading...');
             fs.readFile(deploy_package, function (err, data) {
@@ -102,7 +102,7 @@ module.exports = function (grunt) {
                 var codeParams = {
                     FunctionName: deploy_function,
                     ZipFile: data
-                }
+                };
 
                 lambda.updateFunctionCode(codeParams, function (err, data) {
                     if (err) {


### PR DESCRIPTION
Fixes to two JSHint missing semicolon errors. 