### PR TITLE
Adding deploy options.region docs back to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,12 @@ Default value: `null`
 
 If you wish to use a specific AWS credentials profile you can specify it here, otherwise it will use the environment default.
 
+##### options.region
+Type: `String`
+Default value: `us-east-1`
+
+Specify the AWS region your functions will be uploaded to.
+
 ##### options.timeout
 Type: `Integer`
 Default value: `null`


### PR DESCRIPTION
Replacing the documentation for `options.region` removed earlier in b92dd4d9899cb76e7a29358a0f4ed8f87519119b. 