### PR TITLE
Parsing AWS region from ARN, when ARN provided

### DIFF
--- a/tasks/lambda_deploy.js
+++ b/tasks/lambda_deploy.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
     var path = require('path');
     var fs = require('fs');
     var AWS = require('aws-sdk');
-
+    var arnParser = require('../utils/arn_parser');
 
     // Please see the Grunt documentation for more information regarding task
     // creation: http://gruntjs.com/creating-tasks
@@ -44,6 +44,10 @@ module.exports = function (grunt) {
 
         if(deploy_arn !== null) {
             deploy_function = deploy_arn;
+            var functionInfo = arnParser.parse(deploy_arn);
+            if (functionInfo && functionInfo.region) {
+                options.region = functionInfo.region;
+            }
         }
 
         var done = this.async();

--- a/test/arn_parser_test.js
+++ b/test/arn_parser_test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var arnParser = require('../utils/arn_parser');
+
+exports.parseFullArn = function(test){
+    var arn = 'arn:aws:lambda:us-west-2:123456789012:function:MyFunctionName';
+    var functionInfo = arnParser.parse(arn);
+    test.ok(functionInfo, 'parser should return function info');
+    test.equal(functionInfo.region, 'us-west-2');
+    test.equal(functionInfo.accountId, '123456789012');
+    test.equal(functionInfo.functionName, 'MyFunctionName');
+    test.done();
+};
+
+exports.parsePartialArn = function(test){
+    var arn = '123456789012:MyFunctionName';
+    var functionInfo = arnParser.parse(arn);
+    test.ok(functionInfo, 'parser should return function info');
+    test.equal(functionInfo.region, undefined);
+    test.equal(functionInfo.accountId, '123456789012');
+    test.equal(functionInfo.functionName, 'MyFunctionName');
+    test.done();
+};
+
+exports.parseFunctionName = function(test){
+    var arn = 'MyFunctionName';
+    var functionInfo = arnParser.parse(arn);
+    test.ok(functionInfo, 'parser should return function info');
+    test.equal(functionInfo.region, undefined);
+    test.equal(functionInfo.accountId, undefined);
+    test.equal(functionInfo.functionName, 'MyFunctionName');
+    test.done();
+};
+
+exports.parseEmptyArn = function(test){
+    var arn = '';
+    var functionInfo = arnParser.parse(arn);
+    test.equal(functionInfo, undefined);
+    test.done();
+};
+
+exports.parseUndefinedArn = function(test){
+    var functionInfo = arnParser.parse(undefined);
+    test.equal(functionInfo, undefined);
+    test.done();
+};
+
+exports.parseBadArn = function(test){
+    var arn = ':#!!';
+    var functionInfo = arnParser.parse(arn);
+    test.equal(functionInfo, undefined);
+    test.done();
+};

--- a/utils/arn_parser.js
+++ b/utils/arn_parser.js
@@ -1,0 +1,31 @@
+var arnParser = {};
+
+/**
+ * Parses Lambda ARNs to identify region and other components
+ * See CreateFunction in the AWS Lambda API Reference for the ARN formats and regex
+ * http://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html
+ *
+ * Acceptable ARN-like formats for Lambda include:
+ *  - Function name only "Thumbnail"
+ *  - Partial ARN "123456789012:Thumbnail"
+ *  - Full ARN "arn:aws:lambda:us-west-2:123456789012:function:ThumbNail"
+ *
+ * @param {string} arn - An ARN-like string specifying the Lambda function.
+ */
+arnParser.parse = function (arn) {
+    if (!arn) {
+        return;
+    }
+    var match = arn.match(/(arn:aws:lambda:)?([a-z]{2}-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)/);
+    if (!match) {
+        return;
+    }
+    var functionInfo = {
+        "region": match[2] ? match[2].replace(":", "") : undefined,
+        "accountId": match[3] ? match[3].replace(":", "") : undefined,
+        "functionName": match[5]
+    };
+    return functionInfo;
+};
+
+module.exports = arnParser;


### PR DESCRIPTION
I wanted to get AWS region parsed out of the ARN, when ARN is provided for deployment.
* Simple ARN parsing
* Unit tests for ARN parsing
* Integrated parsing into lambda_deploy, conditional on ARN being provided in options and region discovered by parsing.