### PR TITLE
delete dead reference to lambda.Configuration

### DIFF
--- a/tasks/lambda_deploy.js
+++ b/tasks/lambda_deploy.js
@@ -63,7 +63,6 @@ module.exports = function (grunt) {
                 }
             }
 
-            var current = data.Configuration;
             var configParams = {};
 
 


### PR DESCRIPTION
this is failing in the current version of things. Looks like `var current` is unused, can we just delete this line? the `.Configuration` parameter no longer exists in the javascript API.