### PR TITLE
Allow for all credential forms

### DIFF
--- a/tasks/lambda_deploy.js
+++ b/tasks/lambda_deploy.js
@@ -24,6 +24,9 @@ module.exports = function (grunt) {
 
         var options = this.options({
             profile: null,
+            accessKeyId: null,
+            secretAccessKey: null,
+            credentialsJSON: null,
             region: 'us-east-1',
             timeout: null,
             memory: null
@@ -33,6 +36,16 @@ module.exports = function (grunt) {
             var credentials = new AWS.SharedIniFileCredentials({profile: options.profile});
             AWS.config.credentials = credentials;
         }
+
+        if (options.accessKeyId !== null && options.secretAccessKey !== null) {
+          AWS.config.update({accessKeyId: options.accessKeyId, secretAccessKey: options.secretAccessKey});
+        }
+
+        if (options.credentialsJSON !== null) {
+          AWS.config.loadFromPath(options.credentialsJSON);
+        }
+
+        AWS.config.update({region: options.region});
 
         var deploy_function = grunt.config.get('lambda_deploy.' + this.target + '.function');
         var deploy_arn = grunt.config.get('lambda_deploy.' + this.target + '.arn');


### PR DESCRIPTION
I totally agree that credentials shouldn't be hardcoded.

Having said that, I think it should be allowed. I just implemented `grunt-aws` and noticed that they support passed in keys but not profiles (although profiles can be used by using the `AWS_PROFILE` environment variable according to the AWS docs). I have a profile setup on my local computer, but other developers on my project may not have the same. I would rather have an IAM user which has specific permissions to support both projects and keep the credentials in an AWS supported credentials JSON file in the repo (yes, in the repo) instead of having to explain differences between hardcoded & profile (in addition to all the other credential methods)

This pull request allows passing in credentials to the library via the Grunt config or a JSON file. It also improves the README.md to list all possible authentication avenues (IAM role, profile, hardcoded, JSON file, environment variables).