### PR TITLE
Fix the deploy config example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,9 @@ In your project's Gruntfile, add a section named `lambda_deploy` to the data obj
 grunt.initConfig({
     lambda_deploy: {
         default: {
+            arn: 'arn:aws:lambda:us-east-1:123456781234:function:my-function',
             options: {
                 // Task-specific options go here.
-                arn: 'arn:aws:lambda:us-east-1:123456781234:function:my-function'
             }
         }
     },


### PR DESCRIPTION
Fixes a small error to do with the location of the 'arn' option in the lambda_deploy task config