### PR TITLE
Pretty print output objects

### DIFF
--- a/tasks/lambda_invoke.js
+++ b/tasks/lambda_invoke.js
@@ -41,14 +41,14 @@ module.exports = function (grunt) {
                 grunt.log.writeln("");
                 grunt.log.writeln("Success!  Message:");
                 grunt.log.writeln("------------------");
-                grunt.log.writeln(result);
+                grunt.log.writeln(JSON.stringify(result, null, '\t'));
                 done(true);
             },
             fail: function (error) {
                 grunt.log.writeln("");
                 grunt.log.writeln("Failure!  Message:");
                 grunt.log.writeln("------------------");
-                grunt.log.writeln(error);
+                grunt.log.writeln(JSON.stringify(error, null, '\t'));
                 done(false);
             },
             awsRequestId: 'LAMBDA_INVOKE',

--- a/test/expected/custom_options
+++ b/test/expected/custom_options
@@ -6,6 +6,6 @@ value3 = value6
 
 Success!  Message:
 ------------------
-Hello World
+"Hello World"
 
 Done, without errors.

--- a/test/expected/default_options
+++ b/test/expected/default_options
@@ -6,6 +6,6 @@ value3 = value3
 
 Success!  Message:
 ------------------
-Hello World
+"Hello World"
 
 Done, without errors.

--- a/test/expected/failure_options
+++ b/test/expected/failure_options
@@ -6,7 +6,7 @@ value3 = value3
 
 Failure!  Message:
 ------------------
-Hello World
+"Hello World"
 Warning: Task "lambda_invoke:failure_options" failed. Use --force to continue.
 
 Aborted due to warnings.


### PR DESCRIPTION
Fixes issue #54 

The result and error objects aren't always strings  so they should be serialized for output.