### PR TITLE
Fix lambda_deploy config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,9 @@ In your project's Gruntfile, add a section named `lambda_deploy` to the data obj
 grunt.initConfig({
     lambda_deploy: {
         default: {
+            arn: 'arn:aws:lambda:us-east-1:123456781234:function:my-function',
             options: {
                 // Task-specific options go here.
-                arn: 'arn:aws:lambda:us-east-1:123456781234:function:my-function'
             }
         }
     },


### PR DESCRIPTION
The `lambda_deploy` example has the `arn` property inside `options`, but it should be at root level.