### PR TITLE
When deploy_arn is not defined in the Gruntfile the value is undefined

### DIFF
--- a/tasks/lambda_deploy.js
+++ b/tasks/lambda_deploy.js
@@ -65,7 +65,7 @@ module.exports = function (grunt) {
             grunt.fail.warn('You must specify either an arn or a function name.');
         }
 
-        if(deploy_arn !== null) {
+        if(deploy_arn) {
             deploy_function = deploy_arn;
             var functionInfo = arnParser.parse(deploy_arn);
             if (functionInfo && functionInfo.region) {


### PR DESCRIPTION
I use the FunctionName to deploy the code. The deploy_arn is undefined for me at this point.

Why don't we just check if the the deploy_arn is true. It cannot be 0, "", null or undefined anyway.