### PR TITLE
added package_folder option to lambda_invoke task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,13 @@ module.exports = function (grunt) {
                     event: 'test/fixtures/event.json',
                     handler: 'myfunction'
                 }
+            },
+            package_folder_options: {
+                options: {
+                    package_folder: 'test/fixtures/package_folder_option',
+                    file_name: 'index.js',
+                    event: '../../../test/fixtures/event.json'
+                }
             }
         },
         lambda_package: {

--- a/tasks/lambda_invoke.js
+++ b/tasks/lambda_invoke.js
@@ -12,8 +12,6 @@ module.exports = function (grunt) {
 
     var path = require('path');
     var fs = require('fs');
-    var process = require('process');
-
 
     // Please see the Grunt documentation for more information regarding task
     // creation: http://gruntjs.com/creating-tasks

--- a/tasks/lambda_invoke.js
+++ b/tasks/lambda_invoke.js
@@ -12,6 +12,7 @@ module.exports = function (grunt) {
 
     var path = require('path');
     var fs = require('fs');
+    var process = require('process');
 
 
     // Please see the Grunt documentation for more information regarding task
@@ -20,6 +21,7 @@ module.exports = function (grunt) {
     grunt.registerMultiTask('lambda_invoke', 'Invokes a lambda function for testing purposes', function () {
 
         var options = this.options({
+            'package_folder': './',
             'handler': 'handler',
             'file_name': 'index.js',
             'event': 'event.json'
@@ -57,10 +59,19 @@ module.exports = function (grunt) {
             identity: null
         };
 
+        var cwd;
+        if(options.package_folder) {
+          cwd = process.cwd();
+          process.chdir(path.resolve(options.package_folder));
+        }
+        
         var lambda = require(path.resolve(options.file_name));
         var event = JSON.parse(fs.readFileSync(path.resolve(options.event), "utf8"));
         lambda[options.handler](event, context);
-
+        
+        if(cwd) {
+          process.chdir(cwd);
+        }
     });
 
 };

--- a/test/fixtures/package_folder_option/.test
+++ b/test/fixtures/package_folder_option/.test
@@ -1,0 +1,1 @@
+Hello World

--- a/test/fixtures/package_folder_option/index.js
+++ b/test/fixtures/package_folder_option/index.js
@@ -1,0 +1,3 @@
+exports.handler = function (event, context) {
+    context.done(null, process.cwd());
+};

--- a/test/fixtures/package_folder_option/package.json
+++ b/test/fixtures/package_folder_option/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "my-lambda-function",
+    "description": "An Example Lamda Function",
+    "version": "0.0.1",
+    "private": "true",
+    "dependencies": {
+    },
+    "devDependencies": {
+    },
+    "bundledDependencies": [
+    ]
+}

--- a/test/lambda_invoke_test.js
+++ b/test/lambda_invoke_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var grunt = require('grunt');
+var path = require('path');
 
 /*
  ======== A Handy Little Nodeunit Reference ========
@@ -70,6 +71,30 @@ exports.lambda_invoke = {
             var expected = getNormalizedFile('test/expected/failure_options');
             var actual = grunt.util.normalizelf(result.stdout);
             test.equal(actual, expected);
+            test.done();
+        });
+    },
+    package_folder_options: function (test) {
+        test.expect(2);
+
+        grunt.util.spawn({
+            grunt: true,
+            args: ['lambda_invoke:package_folder_options', '--no-color']
+        }, function (err, result, code) {
+
+            var cwd = process.cwd();
+
+            // test cwd inside the function
+            var expected_cwd = 'Running "lambda_invoke:package_folder_options" (lambda_invoke) task\n\n\nSuccess!  Message:\n------------------\n' +
+              path.join(cwd, 'test/fixtures/package_folder_option') +
+              '\n\nDone, without errors.';
+              
+            var actual_cwd = grunt.util.normalizelf(result.stdout);
+            test.equal(actual_cwd, expected_cwd);
+
+            // test back from the function
+            test.equal(process.cwd(), cwd);
+
             test.done();
         });
     }


### PR DESCRIPTION
This simple addition makes invoke consistent with package.

In fact you can now invoke a lambda function from another folder: using `package_folder` option, the current execution folder will be changed to it so the related modules can be found.

This is useful for example when dealing with many functions and avoid continuously changing folder in the shell.