### PR TITLE
add option "include_basedir" to add additional binary module files

### DIFF
--- a/tasks/lambda_package.js
+++ b/tasks/lambda_package.js
@@ -29,7 +29,8 @@ module.exports = function (grunt) {
             'dist_folder': 'dist',
             'include_time': true,
             'package_folder': './',
-            'include_files': []
+            'include_files': [],
+            'include_basedir': './'
         });
 
         var pkg = grunt.file.readJSON(path.resolve(options.package_folder + '/package.json'));
@@ -91,14 +92,14 @@ module.exports = function (grunt) {
                         cwd: install_location + '/node_modules/' + pkg.name
                     }
                 ]);
-
+debugger;
                 if (options.include_files.length) {
                     zipArchive.bulk([
                         {
                             src: options.include_files,
                             dot: true,
                             expand: true,
-                            cwd: options.package_folder
+                            cwd: options.include_basedir
                         }
                     ]);
                 }


### PR DESCRIPTION
**use case:**
I have an folder "./node_modules_lambda" which is listed in ".npmignore" and contains "./node_modules_lambda/node_modules/fibers/bin/linux-x64-v8-3.14/fibers.node" which is the binary specific for the was lambda environment.

```
lambda_package: {
        default: {
            options: {
                include_files: [  './node_modules/fibers/bin/linux-x64-v8-3.14/**/*' ],
                include_basedir: './node_modules_lambda'
         }
     }
 },
```