### PR TITLE
replace slash with hyphen in archive name for scoped packages

### DIFF
--- a/utils/package_task.js
+++ b/utils/package_task.js
@@ -43,7 +43,7 @@ packageTask.getHandler = function (grunt) {
             time_string = dateFacade.getFormattedTimestamp(new Date());
         }
 
-        var archive_name = pkg.name;
+        var archive_name = pkg.name.replace(/\//g, '-');
 
         if (options.include_version) {
             archive_name += '_' + pkg.version.replace(/\./g, '-');


### PR DESCRIPTION
When packaging a scoped package, following error is displayed because of the '/' in package name. scoped packages have naming convention @somescope/somepackagename . fixed by replacing '/' with '-'

Running "lambda_package:default" (lambda_package) task
Fatal error: ENOENT: no such file or directory, open 'C:\Users\****\AppData\Local\Temp\1457437821029.6345\@az\bit-api_1-0-0_2016-2-9-0-50-21.zip'
