### PR TITLE
Call AWS.config.update after parsing region

### DIFF
--- a/test/unit/deploy_task_test.js
+++ b/test/unit/deploy_task_test.js
@@ -239,6 +239,32 @@ deployTaskTest.testRegion = function(test) {
     gruntMock.execute(deployTask.getHandler, harnessParams);
 };
 
+deployTaskTest.testFunctionArn = function(test) {
+    test.expect(4);
+
+    var deployTask = require('../../utils/deploy_task');
+
+    var functionArn = 'arn:aws:lambda:us-west-2:123456789012:function:MyFunctionName';
+    var configWithArn = {
+        'lambda_deploy.fake-target.package': './dist/some-package.zip',
+        'lambda_deploy.fake-target.arn': functionArn
+    };
+
+    var harnessParams = {
+        options: {},
+        config: configWithArn,
+        callback: function(harness) {
+            test.equal(harness.status, true);
+            test.equal(harness.output.length, 3);
+
+            test.ok(awsSDKMock.config.update.calledWith({region: 'us-west-2'}));
+            test.ok(lambdaAPIMock.getFunction.calledWith({FunctionName: functionArn}));
+            test.done();
+        }
+    };
+    gruntMock.execute(deployTask.getHandler, harnessParams);
+};
+
 deployTaskTest.testTimeout = function(test) {
     test.expect(4);
 

--- a/utils/deploy_task.js
+++ b/utils/deploy_task.js
@@ -60,8 +60,6 @@ deployTask.getHandler = function (grunt) {
             AWS.config.loadFromPath(options.credentialsJSON);
         }
 
-        AWS.config.update({region: options.region});
-
         if (typeof options.aliases === 'string') {
             options.aliases = [options.aliases];
         }
@@ -84,6 +82,8 @@ deployTask.getHandler = function (grunt) {
                 options.region = functionInfo.region;
             }
         }
+
+        AWS.config.update({region: options.region});
 
         var done = this.async();
 


### PR DESCRIPTION
The README suggests that the `options.region` parameter is not required when specifying an `arn` for the `lambda_deploy` task. However, I was finding this not to be the case, and it looked like what was happening was the region was being set before it was parsed from the `arn`. This PR attempts to fix this.
