### PR TITLE
Move AWS config update region to handle region parsed in ARN

### DIFF
--- a/utils/deploy_task.js
+++ b/utils/deploy_task.js
@@ -71,8 +71,6 @@ deployTask.getHandler = function (grunt) {
             AWS.config.loadFromPath(options.credentialsJSON);
         }
 
-        AWS.config.update({region: options.region});
-
         if (typeof options.aliases === 'string') {
             options.aliases = [options.aliases];
         }
@@ -95,6 +93,8 @@ deployTask.getHandler = function (grunt) {
                 options.region = functionInfo.region;
             }
         }
+        
+        AWS.config.update({region: options.region});
 
         var done = this.async();
 


### PR DESCRIPTION
Small modification to do AWS.config.update({region..}) after parsing the ARN.

When done before all functions not in us-east-1 result in : 
[ResourceNotFoundException: Functions from '_region_' are not reachable in this region ('us-east-1')]
