### PR TITLE
Updated aws-sdk dependency to enable STS / assume role behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "mkdirp": "~0.5.0",
         "rimraf": "~2.2.8",
         "glob": "~4.3.0",
-        "aws-sdk": "~2.2.32",
+        "aws-sdk": "~2.6.3",
 	    "proxy-agent": "latest",
         "npm": "^2.10.0",
         "q": "^1.4.1"


### PR DESCRIPTION
To enable the AWS security token service and the possible to assume roles in different accounts I updated the aws-sdk dependency. Works for me, the only issue I had was to a different node.js version.
