### PR TITLE
Enabled to set session token for hardcoded AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,12 @@ Default value: `null`
 
 If you wish to use hardcoded AWS credentials you should specify the Secret Access Key here
 
+##### options.sessionToken
+Type: `String`
+Default value: `null`
+
+If you wish to use hardcoded AWS credentials and you need to specify session token. This is an optional AWS session token. Usually you will need just `accessKeyId` and `secretAccessKey`.
+
 ##### options.credentialsJSON
 Type: `String`
 Default value: `null`

--- a/utils/deploy_task.js
+++ b/utils/deploy_task.js
@@ -30,6 +30,7 @@ deployTask.getHandler = function (grunt) {
             RoleArn: null,
             accessKeyId: null,
             secretAccessKey: null,
+            sessionToken: null,
             credentialsJSON: null,
             region: 'us-east-1',
             timeout: null,
@@ -64,7 +65,16 @@ deployTask.getHandler = function (grunt) {
         }
 
         if (options.accessKeyId !== null && options.secretAccessKey !== null) {
-            AWS.config.update({accessKeyId: options.accessKeyId, secretAccessKey: options.secretAccessKey});
+            var sdkCredentials = {
+                accessKeyId: options.accessKeyId,
+                secretAccessKey: options.secretAccessKey
+            };
+
+            if (options.sessionToken !== null) {
+                sdkCredentials.sessionToken = options.sessionToken;
+            }
+
+            AWS.config.update(sdkCredentials);
         }
 
         if (options.credentialsJSON !== null) {


### PR DESCRIPTION
The purpose of this PR is to be able set up session token for AWS SDK when using hardcoded AWS credentials.
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html#sessionToken-property