### PR TITLE
Moving the region update statement till after it has been extracted from arn

### DIFF
--- a/utils/deploy_task.js
+++ b/utils/deploy_task.js
@@ -71,7 +71,6 @@ deployTask.getHandler = function (grunt) {
             AWS.config.loadFromPath(options.credentialsJSON);
         }
 
-        AWS.config.update({region: options.region});
 
         if (typeof options.aliases === 'string') {
             options.aliases = [options.aliases];
@@ -95,6 +94,8 @@ deployTask.getHandler = function (grunt) {
                 options.region = functionInfo.region;
             }
         }
+
+        AWS.config.update({region: options.region});
 
         var done = this.async();
 


### PR DESCRIPTION
It is a really small fix but it took me some time to figure this out. The error I was getting is:

    Running "lambda_deploy:default" (lambda_deploy) task 
    Warning: Unable to find lambda function arn:aws:lambda:eu-west-1:<redacted>:function:<redacted>, verify the lambda function name and AWS region are correct. Use --force to continue.

In my grunt file I have had added the following snippet to the `initConfig`

        lambda_deploy: {
              default: {
                     arn: "arn:aws:lambda:eu-west-1:<redaced>:function:<redacted>",
                     options: {
                     }
              }
        }

The docs specify other option as optional "if the ARN is provided"

     Specify the AWS region your functions will be uploaded to. Note that if an ARN is supplied this option is not required.

At last I started looking through the code to see what is happening and realised that if I don't specify region in the options, it is being extracted from the ARN, but a little bit too late.

I'm moving it below couple line, so that it works in both cases - either region provided by options or extracted from ARN.
