### PR TITLE
Invoke error messages: returned callback(new Error('some message')) always printing {}

### DIFF
--- a/utils/invoke_task.js
+++ b/utils/invoke_task.js
@@ -87,7 +87,7 @@ invokeTask.getHandler = function (grunt) {
                 grunt.log.writeln("");
                 grunt.log.writeln("Failure!  Message:");
                 grunt.log.writeln("------------------");
-                var msg = (typeof(error) === 'object') ? JSON.stringify(error) : error;
+                var msg = (typeof(error) === 'object') ? JSON.stringify(error, ["message", "arguments", "type", "name"]) : error;
                 grunt.log.writeln((typeof(error) !== 'undefined') ? msg : "Error not provided.");
                 done(false);
             },


### PR DESCRIPTION
By default ```JSON.stringify(new Error(‘some error message’))``` will always print ``{}``. In order to get a comprehensive error message we need to specifiy which properties of the error message to print out. 

see this article for more details 
[https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify](https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify)