### PR TITLE
Upgrade dependencies to resolve vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "temporary": "~0.0.8",
-        "archiver": "~3.0.0",
+        "archiver": "~1.0.0",
         "mkdirp": "~0.5.0",
         "rimraf": "~2.2.8",
         "glob": "~7.1.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "temporary": "~0.0.8",
-        "archiver": "~0.14.4",
+        "archiver": "~3.0.0",
         "mkdirp": "~0.5.0",
         "rimraf": "~2.2.8",
         "glob": "~7.1.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "archiver": "~0.14.4",
         "mkdirp": "~0.5.0",
         "rimraf": "~2.2.8",
-        "glob": "~4.3.0",
+        "glob": "~7.1.4",
         "aws-sdk": "~2.2.32",
 	    "proxy-agent": "latest",
         "npm": "^2.10.0",


### PR DESCRIPTION
Since `glob` version `4.x.x` contains as dependency a version of `minimatch` reported as vulnerable, I have upgraded it to make the repo safe. I had to upgrade `archiver` version too because it use the same unsafe version of `glob`. 